### PR TITLE
Add organization field to block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `organization` field to the `OpenAICredentials` - [#8](https://github.com/PrefectHQ/prefect-openai/pull/8)
+
 ### Changed
 
 ### Deprecated

--- a/prefect_openai/credentials.py
+++ b/prefect_openai/credentials.py
@@ -1,6 +1,7 @@
 """This is an example blocks module"""
 
 from types import ModuleType
+from typing import Optional
 
 import openai
 from prefect.blocks.abstract import CredentialsBlock
@@ -32,6 +33,12 @@ class OpenAICredentials(CredentialsBlock):
         description="The API key used to authenticate with OpenAI.",
     )
 
+    organization: Optional[str] = Field(
+        default=None,
+        title="Organization",
+        description="The organization to use for the OpenAI API.",
+    )
+
     def get_client(self) -> ModuleType:
         """
         Gets the OpenAPI client.
@@ -40,4 +47,5 @@ class OpenAICredentials(CredentialsBlock):
             The OpenAPI client.
         """
         openai.api_key = self.api_key.get_secret_value()
+        openai.organization = self.organization
         return openai

--- a/prefect_openai/credentials.py
+++ b/prefect_openai/credentials.py
@@ -36,7 +36,7 @@ class OpenAICredentials(CredentialsBlock):
     organization: Optional[str] = Field(
         default=None,
         title="Organization",
-        description="The organization to use for the OpenAI API.",
+        description="Specify which organization is used for an API request.",
     )
 
     def get_client(self) -> ModuleType:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -4,7 +4,7 @@ from prefect_openai.credentials import OpenAICredentials
 def test_openai_credentials_get_client():
     credentials = OpenAICredentials(api_key="api_key", organization="my_org")
     assert credentials.api_key.get_secret_value() == "api_key"
-    assert credentials.organization.get_secret_value() == "my_org"
+    assert credentials.organization == "my_org"
 
     client = credentials.get_client()
     assert client.api_key == "api_key"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -2,8 +2,10 @@ from prefect_openai.credentials import OpenAICredentials
 
 
 def test_openai_credentials_get_client():
-    credentials = OpenAICredentials(api_key="api_key")
+    credentials = OpenAICredentials(api_key="api_key", organization="my_org")
     assert credentials.api_key.get_secret_value() == "api_key"
+    assert credentials.organization.get_secret_value() == "my_org"
 
     client = credentials.get_client()
     assert client.api_key == "api_key"
+    assert client.organization == "my_org"


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Allows users to choose which organization to incur token costs on.

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-openai/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-openai/blob/main/CHANGELOG.md)
