### PR TITLE
Decorator using OpenAI to interpret exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `organization` field to the `OpenAICredentials` - [#8](https://github.com/PrefectHQ/prefect-openai/pull/8)
+- `interpret_exception` decorator - [#11](https://github.com/PrefectHQ/prefect-openai/pull/11)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ Notice how the original traceback was quite long and confusing.
 
 On the flip side, the Curie GPT3 model was able to summarize the issue eloquently!
 
+!!! info "Built-in decorator"
+
+    No need to build this yourself, `prefect-openai` features a
+    [built-in decorator](completion/#prefect_openai.completion.interpret_exception)
+    to help you automatically catch and interpret exceptions in flows, tasks, and even
+    vanilla Python functions.
+
+    ```python
+    import httpx
+    from prefect_openai.completion import interpret_exception
+
+    @interpret_exception("COMPLETION_MODEL_BLOCK_NAME_PLACEHOLDER")
+    def example_func():
+        resp = httpx.get("https://httpbin.org/status/403")
+        resp.raise_for_status()
+
+    example_func()
+    ```
+
 ## Create a story around a flow run name with GPT3 and DALL-E
 
 Have you marveled at all the AI-generated images and wondered how others did it?

--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -184,18 +184,18 @@ async def _raise_interpreted_exc(block_name: str, exc: Exception):
             # no signature available like ZeroDivisionError
             kwargs = {}
 
-            # create a new message
-            completion_model = await CompletionModel.load(block_name)
-            prompt = f"Summarize: ```{str(exc)}```."
-            response = await completion_model.submit_prompt(prompt)
-            interpretation = f"{response.choices[0].text.strip()}"
-            new_exc_msg = f"{exc}\nOpenAI: {interpretation}"
+        # create a new message
+        completion_model = await CompletionModel.load(block_name)
+        prompt = f"Summarize: ```{str(exc)}```."
+        response = await completion_model.submit_prompt(prompt)
+        interpretation = f"{response.choices[0].text.strip()}"
+        new_exc_msg = f"{exc}\nOpenAI: {interpretation}"
 
-            # push the original traceback to the tail so it's not obscured by
-            # the additional logic in this except clause
-            raise exc_type(new_exc_msg, *args, **kwargs).with_traceback(
-                exc_traceback
-            ) from exc
+        # push the original traceback to the tail so it's not obscured by
+        # the additional logic in this except clause
+        raise exc_type(new_exc_msg, *args, **kwargs).with_traceback(
+            exc_traceback
+        ) from exc
     except Exception:
         # if anything unexpected goes wrong, just raise the original exception
         raise

--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -186,7 +186,7 @@ async def _raise_interpreted_exc(block_name: str, exc: Exception):
 
         # create a new message
         completion_model = await CompletionModel.load(block_name)
-        prompt = f"Summarize: ```{str(exc)}```."
+        prompt = f"Interpret & explain: ```\n{str(exc)}\n```"
         response = await completion_model.submit_prompt(prompt)
         interpretation = f"{response.choices[0].text.strip()}"
         new_exc_msg = f"{exc}\nOpenAI: {interpretation}"
@@ -218,13 +218,15 @@ def interpret_exception(completion_model_name: str) -> Callable:
     Examples:
         Interpret the exception raised from a flow.
         ```python
+        import httpx
         from prefect import flow
         from prefect_openai.completion import interpret_exception
 
         @flow
-        @interpret_exception("BLOCK_NAME")
+        @interpret_exception("COMPLETION_MODEL_BLOCK_NAME_PLACEHOLDER")
         def example_flow():
-            return 1 / 0
+            resp = httpx.get("https://httpbin.org/status/403")
+            resp.raise_for_status()
 
         example_flow()
         ```

--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -183,6 +183,20 @@ def interpret_exception(block_name: str) -> Callable:
     Returns:
         A decorator that will use an OpenAI CompletionModel to interpret the exception
         raised from the decorated function.
+    
+    Examples:
+        Interpret the exception raised from a flow.
+        ```python
+        from prefect import flow
+        from prefect_openai.completion import interpret_exception
+
+        @interpret_exception("BLOCK_NAME")
+        @flow
+        def example_flow():
+            return 1 / 0
+
+        example_flow()
+        ```
     """
 
     def decorator(fn: Callable) -> Callable:

--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -1,7 +1,6 @@
 """Module for generating and configuring OpenAI completions."""
 import functools
 import inspect
-import sys
 from logging import Logger
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
@@ -171,7 +170,7 @@ async def _raise_interpreted_exc(block_name: str, exc: Exception):
     try:
         # gather args and kwargs from the original exception to rebuild
         exc_type = type(exc)
-        exc_traceback = sys.exc_info()[-1]
+        exc_traceback = exc.__traceback__
         args = exc.args[1:]  # first arg is message, which we're overwriting
         try:
             signature = inspect.signature(exc_type)
@@ -193,9 +192,7 @@ async def _raise_interpreted_exc(block_name: str, exc: Exception):
 
         # push the original traceback to the tail so it's not obscured by
         # the additional logic in this except clause
-        raise exc_type(new_exc_msg, *args, **kwargs).with_traceback(
-            exc_traceback
-        ) from exc
+        raise exc_type(new_exc_msg, *args, **kwargs).with_traceback(exc_traceback)
     except Exception:
         # if anything unexpected goes wrong, just raise the original exception
         raise

--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -183,7 +183,7 @@ def interpret_exception(block_name: str) -> Callable:
     Returns:
         A decorator that will use an OpenAI CompletionModel to interpret the exception
         raised from the decorated function.
-    
+
     Examples:
         Interpret the exception raised from a flow.
         ```python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ mkdocs-gen-files
 interrogate
 coverage
 pillow
+respx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from prefect.testing.utilities import MagicMock, prefect_test_harness
+from prefect.testing.utilities import AsyncMock, MagicMock, prefect_test_harness
 
 from prefect_openai.credentials import OpenAICredentials
 
@@ -34,7 +34,13 @@ async def mock_acreate(prompt, **kwargs):
 @pytest.fixture
 def mock_openai_credentials(monkeypatch) -> OpenAICredentials:
     mock_model = MagicMock()
+    mock_block_load = AsyncMock()
     mock_model.acreate.side_effect = mock_acreate
     monkeypatch.setattr("openai.Completion", mock_model)
     monkeypatch.setattr("openai.Image", mock_model)
-    return OpenAICredentials(api_key="my_api_key", _mock_model=mock_model)
+    monkeypatch.setattr(
+        "prefect_openai.completion.CompletionModel.load", mock_block_load
+    )
+    return OpenAICredentials(
+        api_key="my_api_key", _mock_model=mock_model, _mock_block_load=mock_block_load
+    )

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,6 +1,11 @@
 from unittest.mock import MagicMock
 
-from prefect_openai.completion import CompletionModel
+import pytest
+from prefect import flow
+from prefect.client.schemas import State
+from prefect.utilities.asyncutils import is_async_fn
+
+from prefect_openai.completion import CompletionModel, interpret_exception
 
 
 def test_completion_model_create(mock_openai_credentials: MagicMock):
@@ -35,3 +40,64 @@ def test_completion_model_create_override(mock_openai_credentials: MagicMock):
         echo=False,
         timeout=None,
     )
+
+
+class TestInterpretException:
+    def sync_fn(divisor: int):
+        return 1 / divisor
+
+    async def async_fn(divisor: int):
+        return 1 / divisor
+
+    @flow
+    def sync_flow(divisor: int):
+        return 1 / divisor
+
+    @flow
+    async def async_flow(divisor: int):
+        return 1 / divisor
+
+    @pytest.mark.parametrize("fn", [sync_fn, async_fn, sync_flow, async_flow])
+    async def test_interpret_exception_no_error(self, mock_openai_credentials, fn):
+        decorated_fn = interpret_exception("curie")(fn)
+        if is_async_fn(fn):
+            assert (await decorated_fn(1)) == 1
+        else:
+            assert decorated_fn(1) == 1
+        assert mock_openai_credentials._mock_block_load.call_count == 0
+
+    @pytest.mark.parametrize("fn", [sync_fn, sync_flow])
+    def test_interpret_exception_error(self, mock_openai_credentials, fn):
+        decorated_fn = interpret_exception("curie")(fn)
+        with pytest.raises(ZeroDivisionError) as exc_info:
+            decorated_fn(0)
+        assert exc_info.value.args[0].startswith("[OpenAI Interpretation]")
+        mock_openai_credentials._mock_block_load.assert_called_once_with("curie")
+
+    @pytest.mark.parametrize("fn", [async_fn, async_flow])
+    async def test_interpret_exception_error_async(self, mock_openai_credentials, fn):
+        decorated_fn = interpret_exception("curie")(fn)
+        with pytest.raises(ZeroDivisionError) as exc_info:
+            await decorated_fn(0)
+        assert exc_info.value.args[0].startswith("[OpenAI Interpretation]")
+        mock_openai_credentials._mock_block_load.assert_called_once_with("curie")
+
+    def test_interpret_exception_flow_return_state(self, mock_openai_credentials):
+        decorated_fn = interpret_exception("curie")(self.sync_flow)
+        result = decorated_fn(0, return_state=True)
+        assert isinstance(result, State)
+        assert result.message.startswith("[OpenAI Interpretation]")
+        assert str(result.data) == result.message
+        assert isinstance(result.data, ZeroDivisionError)
+        mock_openai_credentials._mock_block_load.assert_called_once_with("curie")
+
+    async def test_interpret_exception_flow_return_state_async(
+        self, mock_openai_credentials
+    ):
+        decorated_fn = interpret_exception("curie")(self.async_flow)
+        result = await decorated_fn(0, return_state=True)
+        assert isinstance(result, State)
+        assert result.message.startswith("[OpenAI Interpretation]")
+        assert str(result.data) == result.message
+        assert isinstance(result.data, ZeroDivisionError)
+        mock_openai_credentials._mock_block_load.assert_called_once_with("curie")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -164,6 +164,17 @@ class TestInterpretExceptionError:
         mock_openai_credentials._mock_block_load.assert_called_once_with("curie")
         assert mock_openai_credentials._mock_block_load.call_count == 1
 
+    def test_flow_args(self, mock_openai_credentials):
+        """
+        Test whether flow kwargs are still working.
+        """
+        my_flow = flow(self.sync_fn, retries=2)
+        assert my_flow.retries == 2
+        with pytest.raises(ZeroDivisionError, match="\nOpenAI"):
+            my_flow(0)
+        # 2 retries + original try == 3
+        assert mock_openai_credentials._mock_block_load.call_count == 3
+
     def test_httpx_error(self, mock_openai_credentials, respx_mock):
         """
         Some errors, like HttpError, have additional args/kwargs to rebuild.

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -206,7 +206,7 @@ class TestInterpretExceptionError:
         def custom_fn():
             raise CustomException("For testing only...", 1, keyword="keyword")
 
-        with pytest.raises(CustomException, match="\nOpenAI"):
+        with pytest.raises(CustomException, match="OpenAI"):
             custom_fn()
 
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Turns out there's a lot of edge cases to cover:
- sync vs async
- return_state vs not
- flow vs not

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```
from prefect import flow
from prefect_openai.completion import interpret_exception

@interpret_exception("curie")
@flow
def test_flow():
    return 1 / 0

test_flow()
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
![image](https://user-images.githubusercontent.com/15331990/214198573-05d36516-8304-4f80-8d7d-e7d215783be4.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-openai/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-openai/blob/main/CHANGELOG.md)
