### PR TITLE
Add prompt_prefix and traceback_tail to offer customization on tweaking the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `organization` field to the `OpenAICredentials` - [#8](https://github.com/PrefectHQ/prefect-openai/pull/8)
 - `interpret_exception` decorator - [#11](https://github.com/PrefectHQ/prefect-openai/pull/11)
+- `prompt_prefix` and `traceback_tail` keyword args to `interpret_exception` - [#14](https://github.com/PrefectHQ/prefect-openai/pull/14)
 
 ### Changed
 

--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -246,7 +246,7 @@ def interpret_exception(
         example_flow()
         ```
 
-        Use a unique prefix and include the last line of the traceback for the prompt.
+        Use a unique prefix and include the last line of the traceback in the prompt.
         ```python
         import httpx
         from prefect import flow
@@ -263,6 +263,7 @@ def interpret_exception(
             resp.raise_for_status()
 
         example_flow()
+        ```
     """
 
     def decorator(fn: Callable) -> Callable:

--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -1,6 +1,7 @@
 """Module for generating and configuring OpenAI completions."""
 import functools
 import inspect
+import traceback
 from logging import Logger
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
@@ -163,7 +164,9 @@ class CompletionModel(Block):
 
 
 @sync_compatible
-async def _raise_interpreted_exc(block_name: str, exc: Exception):
+async def _raise_interpreted_exc(
+    block_name: str, prompt_prefix: str, traceback_tail: int, exc: Exception
+):
     """
     Helper function for reuse so that this doesn't get repeated for sync/async flavors.
     """
@@ -185,7 +188,14 @@ async def _raise_interpreted_exc(block_name: str, exc: Exception):
 
         # create a new message
         completion_model = await CompletionModel.load(block_name)
-        prompt = f"Interpret & explain: ```\n{str(exc)}\n```"
+        if traceback_tail > 0:
+            traceback_lines = "".join(
+                traceback.format_tb(exc.__traceback__)[-traceback_tail:]
+            )
+            exc_input = f"{traceback_lines}\n{exc}"
+        else:
+            exc_input = str(exc)
+        prompt = f"{prompt_prefix} ```\n{exc_input}\n```"
         response = await completion_model.submit_prompt(prompt)
         interpretation = f"{response.choices[0].text.strip()}"
         new_exc_msg = f"{exc}\nOpenAI: {interpretation}"
@@ -198,7 +208,9 @@ async def _raise_interpreted_exc(block_name: str, exc: Exception):
         raise
 
 
-def interpret_exception(completion_model_name: str) -> Callable:
+def interpret_exception(
+    completion_model_name: str, prompt_prefix: str = "Explain:", traceback_tail: int = 0
+) -> Callable:
     """
     Use OpenAI to interpret the exception raised from the decorated function.
     If used with a flow and return_state=True, will override the original state's
@@ -207,6 +219,12 @@ def interpret_exception(completion_model_name: str) -> Callable:
     Args:
         completion_model_name: The name of the CompletionModel
             block to use to interpret the caught exception.
+        prompt_prefix: The prefix to include in the prompt ahead of the traceback
+            and exception message.
+        traceback_tail: The number of lines of the original traceback to include
+            in the prompt to OpenAI, starting from the tail. If 0, only include the
+            exception message in the prompt. Note this can be costly in terms of tokens
+            so be sure to set this and the max_tokens in CompletionModel appropriately.
 
     Returns:
         A decorator that will use an OpenAI CompletionModel to interpret the exception
@@ -227,6 +245,24 @@ def interpret_exception(completion_model_name: str) -> Callable:
 
         example_flow()
         ```
+
+        Use a unique prefix and include the last line of the traceback for the prompt.
+        ```python
+        import httpx
+        from prefect import flow
+        from prefect_openai.completion import interpret_exception
+
+        @flow
+        @interpret_exception(
+            "COMPLETION_MODEL_BLOCK_NAME_PLACEHOLDER",
+            prompt_prefix="Offer a solution:",
+            traceback_tail=1,
+        )
+        def example_flow():
+            resp = httpx.get("https://httpbin.org/status/403")
+            resp.raise_for_status()
+
+        example_flow()
     """
 
     def decorator(fn: Callable) -> Callable:
@@ -247,7 +283,9 @@ def interpret_exception(completion_model_name: str) -> Callable:
             try:
                 return fn(*args, **kwargs)
             except Exception as exc:
-                _raise_interpreted_exc(completion_model_name, exc)
+                _raise_interpreted_exc(
+                    completion_model_name, prompt_prefix, traceback_tail, exc
+                )
 
         # couldn't get sync_compatible working so had to define an async flavor
         @functools.wraps(fn)
@@ -258,7 +296,9 @@ def interpret_exception(completion_model_name: str) -> Callable:
             try:
                 return await fn(*args, **kwargs)
             except Exception as exc:
-                await _raise_interpreted_exc(completion_model_name, exc)
+                await _raise_interpreted_exc(
+                    completion_model_name, prompt_prefix, traceback_tail, exc
+                )
 
         wrapper = async_wrapper if is_async_fn(fn) else sync_wrapper
         return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,9 @@ async def mock_acreate(prompt, **kwargs):
 
 @pytest.fixture
 def mock_openai_credentials(monkeypatch) -> OpenAICredentials:
-    mock_model = MagicMock()
+    mock_model = AsyncMock(name="mock_model")
     mock_block_load = AsyncMock()
+    mock_block_load.return_value = mock_model
     mock_model.acreate.side_effect = mock_acreate
     monkeypatch.setattr("openai.Completion", mock_model)
     monkeypatch.setattr("openai.Image", mock_model)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -241,6 +241,21 @@ class TestInterpretExceptionError:
             "return 1 / divisor\n\ndivision by zero\n```"
         )
 
+    def test_zero_traceback_tail(self, mock_openai_credentials):
+        """
+        Test whether the prompt prefix is added.
+        """
+
+        @interpret_exception("curie", traceback_tail=0)
+        def sync_fn(divisor: int):
+            return 1 / divisor
+
+        with pytest.raises(ZeroDivisionError, match="\nOpenAI"):
+            sync_fn(0)
+        mock_openai_credentials._mock_model.submit_prompt.assert_called_once_with(
+            "Explain: ```\ndivision by zero\n```"
+        )
+
 
 class TestInterpretExceptionImproperUse:
     def test_flow(self):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -220,6 +220,7 @@ class TestInterpretExceptionError:
 
         with pytest.raises(ZeroDivisionError, match="\nOpenAI"):
             sync_fn(0)
+
         mock_openai_credentials._mock_model.submit_prompt.assert_called_once_with(
             "Solution to: ```\ndivision by zero\n```"
         )
@@ -235,11 +236,10 @@ class TestInterpretExceptionError:
 
         with pytest.raises(ZeroDivisionError, match="\nOpenAI"):
             sync_fn(0)
-        mock_openai_credentials._mock_model.submit_prompt.assert_called_once_with(
-            'Explain: ```\n  File "/Users/andrew/Applications/python/prefect-openai/'
-            'tests/test_completion.py", line 234, in sync_fn\n    '
-            "return 1 / divisor\n\ndivision by zero\n```"
-        )
+
+        args_list = mock_openai_credentials._mock_model.submit_prompt.call_args_list[0]
+        input_arg = args_list[0][0]
+        assert "return 1 / divisor\n\ndivision by zero\n`" in input_arg
 
     def test_zero_traceback_tail(self, mock_openai_credentials):
         """


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Add options to tweak the prompt:
- prompt_prefix: the prefix to tell what the model should do with the traceback + exception
- traceback_tail: the last number of lines from the original traceback to include

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

Use a unique prefix and include the last line of the traceback in the prompt.

```python
import httpx
from prefect import flow
from prefect_openai.completion import interpret_exception
@flow
@interpret_exception(
    "COMPLETION_MODEL_BLOCK_NAME_PLACEHOLDER",
    prompt_prefix="Offer a solution:",
    traceback_tail=1,
)
def example_flow():
    resp = httpx.get("https://httpbin.org/status/403")
    resp.raise_for_status()
example_flow()
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-openai/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-openai/blob/main/CHANGELOG.md)
