### PR TITLE
Update the description of OpenAI block

### DIFF
--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -21,8 +21,8 @@ from prefect_openai import OpenAICredentials
 class CompletionModel(Block):
     """
     A block that contains config for an OpenAI Completion Model.
-    Learn more in the [OpenAPI Text Completion docs](
-        https://beta.openai.com/docs/guides/completion)
+    Learn more in the OpenAPI Text Completion docs:
+        https://beta.openai.com/docs/guides/completion
 
     Attributes:
         openai_credentials: The credentials used to authenticate with OpenAI.


### PR DESCRIPTION
The description of the OpenAI block currently looks messy.

![Screenshot 2023-02-22 at 11 24 04 AM](https://user-images.githubusercontent.com/49108771/220707236-088e6243-fd2e-40d9-a9ae-0231cdfee14c.png)

This PR makes the description looks a little bit less messy. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-openai/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-openai/blob/main/CHANGELOG.md)
