### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_openai/completion.py
+++ b/prefect_openai/completion.py
@@ -12,7 +12,13 @@ from prefect.flows import Flow
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.tasks import Task
 from prefect.utilities.asyncutils import is_async_fn, sync_compatible
-from pydantic import Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field
+else:
+    from pydantic import Field
+
 from typing_extensions import Literal
 
 from prefect_openai import OpenAICredentials

--- a/prefect_openai/credentials.py
+++ b/prefect_openai/credentials.py
@@ -5,7 +5,12 @@ from typing import Optional
 
 import openai
 from prefect.blocks.abstract import CredentialsBlock
-from pydantic import Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr
+else:
+    from pydantic import Field, SecretStr
 
 
 class OpenAICredentials(CredentialsBlock):

--- a/prefect_openai/image.py
+++ b/prefect_openai/image.py
@@ -7,7 +7,13 @@ from prefect.blocks.core import Block
 from prefect.exceptions import MissingContextError
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.utilities.asyncutils import sync_compatible
-from pydantic import Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field
+else:
+    from pydantic import Field
+
 from typing_extensions import Literal
 
 from prefect_openai import OpenAICredentials


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.